### PR TITLE
changes location of where to run pre_pre_processing.py

### DIFF
--- a/pre_pre_processing.sh
+++ b/pre_pre_processing.sh
@@ -11,7 +11,7 @@ csplit -s -b "%02d.fasta" -f seq_ -z ../$1 '/>/' {*}
 #2 put all files as porter5 job submisstions in one .swarm file
 ls *.fasta > temp_porter5_submission.swarm
 
-awk '{print "python3 ../Porter5/Porter5.py -i", $0 , "--cpu 4 --fast"}' temp_porter5_submission.swarm > porter5_submission.swarm
+awk '{print "python3 Porter5/Porter5.py -i", $0 , "--cpu 4 --fast"}' temp_porter5_submission.swarm > porter5_submission.swarm
 
 #Porter5 has to be optimised with paths to hhblits, psi-blast, etc...? I'm not sure if it will be a problem?
 printf "Now submit a swarm job with the Porter5_swarm_submission.swarm file in ./split_out\n"


### PR DESCRIPTION
run now from DivProt, not DivProt/split_out

not sure if this is what we want, but I'm pretty sure it is. it should get rid of an odd error from porter with calling ../Potert5/Porter5.py



  File "../Porter5/Porter5.py", line 133, in <module>
    SS[j] = round(prob_hh[i*3+j], 4)
IndexError: list index out of range